### PR TITLE
Remove volunteerpresscenter (bitcoinpresscenter.org)

### DIFF
--- a/_templates/press.html
+++ b/_templates/press.html
@@ -50,8 +50,6 @@ dialogs:
 
 <p>{% translate volunteernonprofit %}</p>
 
-<p>{% translate volunteerpresscenter %}</p>
-
 </div>
 
 </div>


### PR DESCRIPTION
The bitcoinpresscenter.org site is not necessary any more and will not be maintained. Removing from bitcoin.org press page.